### PR TITLE
feat: Display theme in title bar instance field

### DIFF
--- a/templates/full.liquid
+++ b/templates/full.liquid
@@ -21,4 +21,5 @@
 <div class="title_bar">
   <img class="image" src="{{ icon_kfp }}">
   <span class="title">{{ trmnl.plugin_settings.instance_name }}</span>
+  {% if theme and theme != "all" %}<span class="instance">{{ theme | capitalize }}</span>{% endif %}
 </div>

--- a/templates/half_horizontal.liquid
+++ b/templates/half_horizontal.liquid
@@ -21,4 +21,5 @@
 <div class="title_bar">
   <img class="image" src="{{ icon_kfp }}">
   <span class="title">{{ trmnl.plugin_settings.instance_name }}</span>
+  {% if theme and theme != "all" %}<span class="instance">{{ theme | capitalize }}</span>{% endif %}
 </div>

--- a/templates/half_vertical.liquid
+++ b/templates/half_vertical.liquid
@@ -23,4 +23,5 @@
 <div class="title_bar">
   <img class="image" src="{{ icon_kfp }}">
   <span class="title">{{ trmnl.plugin_settings.instance_name }}</span>
+  {% if theme and theme != "all" %}<span class="instance">{{ theme | capitalize }}</span>{% endif %}
 </div>

--- a/templates/quadrant.liquid
+++ b/templates/quadrant.liquid
@@ -10,4 +10,5 @@
 <div class="title_bar">
   <img class="image" src="{{ icon_kfp }}">
   <span class="title">{{ trmnl.plugin_settings.instance_name }}</span>
+  {% if theme and theme != "all" %}<span class="instance">{{ theme | capitalize }}</span>{% endif %}
 </div>


### PR DESCRIPTION
## Overview
Enhance the title bar across all layout templates to display the current quote theme as an instance label, providing users with visual feedback about which theme filter is active.

## Changes
- ✨ Add theme display to title bar across all 4 layouts (full, half_horizontal, half_vertical, quadrant)
- 🎨 Use TRMNL framework `instance` class for consistent styling
- 🔍 Hide theme when set to 'all' (display only for specific theme filters)
- 📝 Capitalize theme text for proper display (e.g., "Wisdom", "Humor", "Growth")

## Technical Details
- Modified all template files to include conditional theme display
- Uses Liquid conditional: `{% if theme and theme != "all" %}`
- Applies `capitalize` filter for proper title-casing
- Follows TRMNL framework title bar pattern with instance labels

## Testing
- ✅ Verified theme appears for specific filters (Wisdom, Humor, etc.)
- ✅ Confirmed theme is hidden when "All Themes" is selected
- ✅ Tested capitalization works correctly
- ✅ Checked across all 4 layout types

## Visual Impact
**Before:** Title bar showed only icon + plugin name  
**After:** Title bar shows icon + plugin name + theme (when filtered)

Example: `[Icon] Kung Fu Panda Quotes | Wisdom`

## Related
- Enhances theme filtering feature introduced earlier
- Improves user experience by showing active filter state
- Aligns with TRMNL framework best practices for title bars